### PR TITLE
fix: secure external GitHub link

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
             </div>
 
             <div style="text-align: center; margin-top: 2rem;">
-                <a href="https://github.com/vcbundertaker/psyDuck" class="cta-button">Ver no GitHub</a>
+                <a href="https://github.com/vcbundertaker/psyDuck" class="cta-button" target="_blank" rel="noopener noreferrer">Ver no GitHub</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- open external GitHub link in a new tab
- prevent `window.opener` leakage using `rel="noopener noreferrer"`

## Testing
- `npx htmlhint index.html` (fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)


------
https://chatgpt.com/codex/tasks/task_e_68af06a1549c8325acdee01d3296e095