### PR TITLE
feat: add danger scanning utility and verification tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,32 @@
             margin-bottom: 2rem;
         }
 
+        nav.tabs {
+            margin-top: 1rem;
+        }
+
+        nav.tabs button {
+            background: var(--secondary-color);
+            border: none;
+            color: white;
+            padding: 0.5rem 1rem;
+            margin: 0 0.25rem;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        nav.tabs button.active {
+            background: var(--accent-color);
+        }
+
+        .tab-content {
+            display: none;
+        }
+
+        .tab-content.active {
+            display: block;
+        }
+
         h1 {
             margin: 0;
             font-size: 2.5rem;
@@ -96,11 +122,15 @@
         <div class="container">
             <h1>psyDuck</h1>
             <p>Projeto de Criptografia Segura</p>
+            <nav class="tabs">
+                <button data-tab="home" class="active">Início</button>
+                <button data-tab="verify">Verificação</button>
+            </nav>
         </div>
     </header>
 
     <div class="container">
-        <div class="content">
+        <div id="home" class="content tab-content active">
             <h2>Sobre o Projeto</h2>
             <p>O psyDuck é um projeto de criptografia que visa fornecer uma solução segura e fácil de usar para proteger suas informações. Utilizando algoritmos modernos e práticas de segurança recomendadas, garantimos a proteção dos seus dados.</p>
 
@@ -123,6 +153,14 @@
                 <a href="https://github.com/vcbundertaker/psyDuck" class="cta-button" target="_blank" rel="noopener noreferrer">Ver no GitHub</a>
             </div>
         </div>
+
+        <div id="verify" class="content tab-content">
+            <h2>Verificação</h2>
+            <textarea id="verify-input" rows="5" style="width:100%;" placeholder="Digite o texto aqui"></textarea>
+            <p>Texto seguro:</p>
+            <pre id="safe-output" style="background:#f7fafc;padding:1rem;border-radius:4px;"></pre>
+            <ul id="flags"></ul>
+        </div>
     </div>
 
     <footer>
@@ -130,5 +168,36 @@
             <p>&copy; 2024 psyDuck. Todos os direitos reservados.</p>
         </div>
     </footer>
+    <script type="module">
+        import { scanDanger } from './src/utils/scanDanger.js';
+
+        const tabs = document.querySelectorAll('nav.tabs button');
+        const contents = document.querySelectorAll('.tab-content');
+        tabs.forEach(btn => {
+            btn.addEventListener('click', () => {
+                contents.forEach(c => c.classList.toggle('active', c.id === btn.dataset.tab));
+                tabs.forEach(b => b.classList.toggle('active', b === btn));
+            });
+        });
+
+        const input = document.getElementById('verify-input');
+        const safeOut = document.getElementById('safe-output');
+        const flagsList = document.getElementById('flags');
+
+        if (input) {
+            input.addEventListener('input', () => {
+                const { safeText, flags } = scanDanger(input.value);
+                if (safeOut) safeOut.textContent = safeText;
+                if (flagsList) {
+                    flagsList.innerHTML = '';
+                    flags.forEach(f => {
+                        const li = document.createElement('li');
+                        li.textContent = `${f.type}: ${f.suggestion} (${f.start}-${f.end})`;
+                        flagsList.appendChild(li);
+                    });
+                }
+            });
+        }
+    </script>
 </body>
-</html> 
+</html>

--- a/src/utils/scanDanger.js
+++ b/src/utils/scanDanger.js
@@ -1,0 +1,45 @@
+const detectors = [
+    {
+        regex: /\b[\w._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+        type: 'PII',
+        mask: () => '***@***.***',
+        suggestion: 'Anonimize o e-mail.'
+    },
+    {
+        regex: /\b(?:\+?\d{1,3}\s?)?(?:\(?\d{2}\)?\s?)?\d{4,5}[-\s]?\d{4}\b/g,
+        type: 'PII',
+        mask: (m) => m.replace(/\d/g, '*'),
+        suggestion: 'Remova o número de telefone.'
+    },
+    {
+        regex: /\b(?:Rua|R\.|Avenida|Av\.?|Estrada|Travessa|Rodovia)\s+[^\n,]*\d+\b/gi,
+        type: 'PII',
+        mask: () => '***',
+        suggestion: 'Oculte o endereço.'
+    },
+    {
+        regex: /\b(?:dose|ml|mg|via|paciente\s+errado)\b/gi,
+        type: 'CLINICAL_RISK',
+        suggestion: 'Reveja o termo clínico.'
+    }
+];
+export function scanDanger(text) {
+    const flags = [];
+    let safeText = text;
+    detectors.forEach(det => {
+        const reg = new RegExp(det.regex.source, det.regex.flags);
+        for (const match of text.matchAll(det.regex)) {
+            const start = match.index ?? 0;
+            flags.push({
+                type: det.type,
+                start,
+                end: start + match[0].length,
+                suggestion: det.suggestion
+            });
+        }
+        if (det.type === 'PII') {
+            safeText = safeText.replace(reg, det.mask);
+        }
+    });
+    return { safeText, flags };
+}

--- a/src/utils/scanDanger.ts
+++ b/src/utils/scanDanger.ts
@@ -1,0 +1,69 @@
+export interface Flag {
+  type: 'PII' | 'CLINICAL_RISK';
+  start: number;
+  end: number;
+  suggestion: string;
+}
+
+interface DetectorBase {
+  regex: RegExp;
+  suggestion: string;
+}
+
+interface PIIDetector extends DetectorBase {
+  type: 'PII';
+  mask: (match: string) => string;
+}
+
+interface RiskDetector extends DetectorBase {
+  type: 'CLINICAL_RISK';
+}
+
+const detectors: (PIIDetector | RiskDetector)[] = [
+  {
+    regex: /\b[\w._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+    type: 'PII',
+    mask: () => '***@***.***',
+    suggestion: 'Anonimize o e-mail.'
+  },
+  {
+    regex: /\b(?:\+?\d{1,3}\s?)?(?:\(?\d{2}\)?\s?)?\d{4,5}[-\s]?\d{4}\b/g,
+    type: 'PII',
+    mask: (m) => m.replace(/\d/g, '*'),
+    suggestion: 'Remova o número de telefone.'
+  },
+  {
+    regex: /\b(?:Rua|R\.|Avenida|Av\.?|Estrada|Travessa|Rodovia)\s+[^\n,]*\d+\b/gi,
+    type: 'PII',
+    mask: () => '***',
+    suggestion: 'Oculte o endereço.'
+  },
+  {
+    regex: /\b(?:dose|ml|mg|via|paciente\s+errado)\b/gi,
+    type: 'CLINICAL_RISK',
+    suggestion: 'Reveja o termo clínico.'
+  }
+];
+
+export function scanDanger(text: string): { safeText: string; flags: Flag[] } {
+  const flags: Flag[] = [];
+  let safeText = text;
+
+  detectors.forEach(det => {
+    const reg = new RegExp(det.regex.source, det.regex.flags);
+    for (const match of text.matchAll(det.regex)) {
+      const start = match.index ?? 0;
+      flags.push({
+        type: det.type,
+        start,
+        end: start + match[0].length,
+        suggestion: det.suggestion
+      });
+    }
+    if (det.type === 'PII') {
+      safeText = safeText.replace(reg, det.mask);
+    }
+  });
+
+  return { safeText, flags };
+}


### PR DESCRIPTION
## Summary
- add scanDanger utility to mask PII and flag clinical risk terms
- expose danger scanning demo via new "Verificação" tab

## Testing
- `tsc src/utils/scanDanger.ts --noEmit --target ES2020 --module ES6`
- `node -e "import('./src/utils/scanDanger.js').then(m=>console.log(m.scanDanger('dose 5mg em Rua Exemplo 123 e email a@b.cd, fone 1234-5678')));"`


------
https://chatgpt.com/codex/tasks/task_e_68c2412d41e08325b8388318332ed2e1